### PR TITLE
docs: Add Additional Models to Benchmarking

### DIFF
--- a/examples/llm/benchmarks/README.md
+++ b/examples/llm/benchmarks/README.md
@@ -22,23 +22,25 @@ This guide provides detailed steps on benchmarking Large Language Models (LLMs) 
 > [!NOTE]
 > We recommend trying out the [LLM Deployment Examples](./README.md) before benchmarking.
 
+
 ## Prerequisites
 
-> [!Important] At least one 8xH100-80GB node is required for benchmarking.
+> [!Important]
+> At least one 8xH100-80GB node is required for the following instructions.
 
-1. Build benchmarking image
+ 1. Build benchmarking image
 
     ```bash
     ./container/build.sh
     ```
 
-2. Download model
+ 2. Download model
 
     ```bash
     huggingface-cli download neuralmagic/DeepSeek-R1-Distill-Llama-70B-FP8-dynamic
     ```
 
-3. Start NATS and ETCD
+ 3. Start NATS and ETCD
 
     ```bash
     docker compose -f deploy/docker_compose.yml up -d
@@ -64,7 +66,8 @@ This guide provides detailed steps on benchmarking Large Language Models (LLMs) 
 
 ## Disaggregated Single Node Benchmarking
 
-> [!Important] One 8xH100-80GB node is required for this setup.
+> [!Important]
+> One 8xH100-80GB node is required for the following instructions.
 
 In the following setup we compare Dynamo disaggregated vLLM performance to
 [native vLLM Aggregated Baseline](#vllm-aggregated-baseline-benchmarking) on a single node. These were chosen to optimize
@@ -76,7 +79,7 @@ Each prefill worker will use tensor parallel 1 and the decode worker will use te
 
 With the Dynamo repository, benchmarking image and model available, and **NATS and ETCD started**, perform the following steps:
 
-1. Run benchmarking container
+ 1. Run benchmarking container
 
     ```bash
     ./container/run.sh --mount-workspace
@@ -85,7 +88,7 @@ With the Dynamo repository, benchmarking image and model available, and **NATS a
     > [!Tip]
     > The huggingface home source mount can be changed by setting `--hf-cache ~/.cache/huggingface`.
 
-2. Start disaggregated services
+ 2. Start disaggregated services
 
     ```bash
     cd /workspace/examples/llm
@@ -95,11 +98,13 @@ With the Dynamo repository, benchmarking image and model available, and **NATS a
     > [!Tip]
     > Check the `disagg.log` to make sure the service is fully started before collecting performance numbers.
 
-3. Collect the performance numbers as shown on the [Collecting Performance Numbers](#collecting-performance-numbers) section below.
+ 3. Collect the performance numbers as shown on the [Collecting Performance Numbers](#collecting-performance-numbers) section below.
 
-## Disaggregated Multi Node Benchmarking
 
-> [!Important] Two 8xH100-80GB nodes are required for this setup.
+## Disaggregated Multinode Benchmarking
+
+> [!Important]
+> Two 8xH100-80GB nodes are required the following instructions.
 
 In the following steps we compare Dynamo disaggregated vLLM performance to
 [native vLLM Aggregated Baseline](#vllm-aggregated-baseline-benchmarking) on two nodes. These were chosen to optimize
@@ -111,7 +116,7 @@ Each prefill worker will use tensor parallel 1 and the decode worker will use te
 
 With the Dynamo repository, benchmarking image and model available, and **NATS and ETCD started on node 0**, perform the following steps:
 
-1. Run benchmarking container (node 0 & 1)
+ 1. Run benchmarking container (nodes 0 & 1)
 
     ```bash
     ./container/run.sh --mount-workspace
@@ -120,7 +125,7 @@ With the Dynamo repository, benchmarking image and model available, and **NATS a
     > [!Tip]
     > The huggingface home source mount can be changed by setting `--hf-cache ~/.cache/huggingface`.
 
-2. Config NATS and ETCD (node 1)
+ 2. Config NATS and ETCD (node 1)
 
     ```bash
     export NATS_SERVER="nats://<node_0_ip_addr>"
@@ -130,7 +135,7 @@ With the Dynamo repository, benchmarking image and model available, and **NATS a
     > [!Important]
     > Node 1 must be able to reach Node 0 over the network for the above services.
 
-3. Start workers (node 0)
+ 3. Start workers (node 0)
 
     ```bash
     cd /workspace/examples/llm
@@ -140,7 +145,7 @@ With the Dynamo repository, benchmarking image and model available, and **NATS a
     > [!Tip]
     > Check the `disagg_multinode.log` to make sure the service is fully started before collecting performance numbers.
 
-4. Start workers (node 1)
+ 4. Start workers (node 1)
 
     ```bash
     cd /workspace/examples/llm
@@ -150,24 +155,26 @@ With the Dynamo repository, benchmarking image and model available, and **NATS a
     > [!Tip]
     > Check the `prefill_multinode.log` to make sure the service is fully started before collecting performance numbers.
 
-5. Collect the performance numbers as shown on the [Collecting Performance Numbers](#collecting-performance-numbers) section above.
+ 5. Collect the performance numbers as shown on the [Collecting Performance Numbers](#collecting-performance-numbers) section above.
+
 
 ## vLLM Aggregated Baseline Benchmarking
 
-> [!Important] One (or two) 8xH100-80GB nodes are required for this setup.
+> [!Important]
+> One (or two) 8xH100-80GB nodes are required the following instructions.
 
 With the Dynamo repository and the benchmarking image available, perform the following steps:
 
-1. Run benchmarking container
+ 1. Run benchmarking container
 
     ```bash
     ./container/run.sh --mount-workspace
     ```
 
     > [!Tip]
-    > The huggingface home source mount can be changed by setting `--hf-cache ~/.cache/huggingface`.
+    > The Hugging Face home source mount can be changed by setting `--hf-cache ~/.cache/huggingface`.
 
-2. Start vLLM serve
+ 2. Start vLLM serve
 
     ```bash
     CUDA_VISIBLE_DEVICES=0,1,2,3 vllm serve neuralmagic/DeepSeek-R1-Distill-Llama-70B-FP8-dynamic \
@@ -189,10 +196,11 @@ With the Dynamo repository and the benchmarking image available, perform the fol
     ```
 
     > [!Tip]
-    > * Check the `vllm_0.log` and `vllm_1.log` to make sure the service is fully started before collecting performance numbers.
-    > * If benchmarking over 2 nodes, `--tensor-parallel-size 8` should be used and only run one `vllm serve` instance per node.
+    > Check the `vllm_0.log` and `vllm_1.log` to make sure the service is fully started before collecting performance numbers.
+    >
+    > If benchmarking with two or more nodes, `--tensor-parallel-size 8` should be used and only run one `vllm serve` instance per node.
 
-3. Use NGINX as load balancer
+ 3. Use NGINX as load balancer
 
     ```bash
     apt update && apt install -y nginx
@@ -203,7 +211,8 @@ With the Dynamo repository and the benchmarking image available, perform the fol
     > [!Note]
     > If benchmarking over 2 nodes, the `upstream` configuration will need to be updated to link to the `vllm serve` on the second node.
 
-4. Collect the performance numbers as shown on the [Collecting Performance Numbers](#collecting-performance-numbers) section below.
+ 4. Collect the performance numbers as shown on the [Collecting Performance Numbers](#collecting-performance-numbers) section below.
+
 
 ## Collecting Performance Numbers
 
@@ -215,4 +224,28 @@ bash -x /workspace/benchmarks/llm/perf.sh
 
 > [!Tip]
 > See [GenAI-Perf tutorial](https://github.com/triton-inference-server/perf_analyzer/blob/main/genai-perf/docs/tutorial.md)
-> for additional information about how to run GenAI-Perf and how to interpret results.
+> @ [GitHub](https://github.com/triton-inference-server/perf_analyzer) for additional information about how to run GenAI-Perf
+> and how to interpret results.
+
+
+## Supporting Additional Models
+
+The instructions above can be used for nearly any model desired.
+More complex setup instructions might be required for certain models.
+The above instruction regarding ETCD, NATS, nginx, dynamo-serve, and GenAI-Perf still apply and can be reused.
+The specifics of deploying with different hardware, in a unique environment, or using another model framework can be adapted using the links below.
+
+Regardless of the deployment mechanism, the GenAI-Perf tool will report the same metrics and measurements so long as an accessible endpoint is available for it to interact with. Use the provided [perf.sh](../../../benchmarks/llm/perf.sh) script to automate the measurement of model throughput and latency against multiple request concurrences.
+
+### Deployment Examples
+
+- [Dynamo Multinode Deployments](../../../docs/examples/multinode.md)
+- [Dynamo TensorRT LLM Deployments](../../../docs/examples/trtllm.md)
+    - [Aggregated Deployment of Very Large Models](../../../docs/examples/multinode.md#aggregated-deployment)
+- [Dynamo vLLM Deployments](../../../docs/examples/llm_deployment.md)
+
+
+## Metrics and Visualization
+
+For instructions on how to acquire per worker metrics and visualize them using Grafana,
+please see the provided [Visualization with Prometheus and Grafana](../../../deploy/metrics/README.md).


### PR DESCRIPTION
This change adds instructions for deploying additional models, model frameworks, etc. to the LLM benchmarking instructions.

[DIS-156](https://linear.app/nvidia-dynamo/issue/DIS-156/add-instructions-for-working-w-prometheus-and-grafana-and-dynamo)
